### PR TITLE
Add spec for making modifications to the repository

### DIFF
--- a/spec/gollum_git_actor_spec.rb
+++ b/spec/gollum_git_actor_spec.rb
@@ -1,18 +1,16 @@
 require 'spec_helper'
 
 describe Gollum::Git::Actor do
-  before(:each) do
-    @repo = Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true)
-    @actor = Gollum::Git::Actor.new("Tom Werner", "tom@example.com")
-  end
+
+  subject(:actor) { Gollum::Git::Actor.new("Tom Werner", "tom@example.com") }
 
   it "should have accessors for name and email" do
-    @actor.should respond_to(:name)
-    @actor.should respond_to(:email)
+    expect(actor).to respond_to(:name)
+    expect(actor).to respond_to(:email)
   end
 
   it "should have an output method" do
-    @actor.should respond_to(:output)
+    expect(actor).to respond_to(:output)
   end
 
 end

--- a/spec/gollum_git_blob_spec.rb
+++ b/spec/gollum_git_blob_spec.rb
@@ -1,44 +1,45 @@
 require 'spec_helper'
 
 describe Gollum::Git::Blob do
-  before(:each) do
-    @repo = Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true)
-    @blob = @repo.commits[0].tree.blobs.first
-  end
+
+  let(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true) }
+
+  subject(:blob) { repo.commits[0].tree.blobs.first }
 
   it "should have a create method that returns a Gollum::Git::Blob" do
-    Gollum::Git::Blob.should respond_to(:create).with(2).arguments
-    test_blob = @repo.head.commit.tree.blobs.first
+    expect(Gollum::Git::Blob).to respond_to(:create).with(2).arguments
+    test_blob = repo.head.commit.tree.blobs.first
     test_options = {:id => test_blob.id, :size => test_blob.size, :mode => test_blob.mode, :path => test_blob.name }
-    Gollum::Git::Blob.create(@repo, test_options).should be_a Gollum::Git::Blob
+    expect(Gollum::Git::Blob.create(repo, test_options)).to be_a Gollum::Git::Blob
   end
-  
+
   it "should have a data method" do
-    @blob.should respond_to(:data)
+    expect(blob).to respond_to(:data)
   end
-  
+
   it "should have a mime-type method" do
-    @blob.should respond_to(:mime_type)
+    expect(blob).to respond_to(:mime_type)
   end
-  
+
   it "should have a name" do
-    @blob.should respond_to(:name)
+    expect(blob).to respond_to(:name)
   end
-  
+
   it "should have an id" do
-    @blob.should respond_to(:id)
+    expect(blob).to respond_to(:id)
   end
-  
+
   it "should have a mode" do
-    @blob.should respond_to(:mode)
+    expect(blob).to respond_to(:mode)
   end
-  
+
   it "should have a size" do
-    @blob.should respond_to(:size)
+    expect(blob).to respond_to(:size)
   end
 
   it "should have an extension for symlinks" do
-    @blob.should respond_to(:is_symlink)
-    @blob.should respond_to(:symlink_target).with(1).argument
+    expect(blob).to respond_to(:is_symlink)
+    expect(blob).to respond_to(:symlink_target).with(1).argument
   end
+
 end

--- a/spec/gollum_git_commit_spec.rb
+++ b/spec/gollum_git_commit_spec.rb
@@ -1,32 +1,32 @@
 require 'spec_helper'
 
 describe Gollum::Git::Commit do
-  before(:each) do
-    @repo = Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true)
-    @commit = @repo.commits.first
-  end
+
+  let(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true) }
+
+  subject(:commit) { repo.commits.first }
 
   it "should have an id, author, authored date, and a message" do
-    @commit.should respond_to(:id)
-    @commit.should respond_to(:author)
-    @commit.should respond_to(:authored_date)
-    @commit.should respond_to(:message)
+    expect(commit).to respond_to(:id)
+    expect(commit).to respond_to(:author)
+    expect(commit).to respond_to(:authored_date)
+    expect(commit).to respond_to(:message)
   end
 
   it "should return a Gollum::Git::Actor object for author" do
-    @commit.author.should be_a Gollum::Git::Actor
+    expect(commit.author).to be_a Gollum::Git::Actor
   end
 
   it "should print the id with to_s" do
-    @commit.to_s.should == @commit.id
+    expect(commit.to_s).to eq commit.id
   end
 
   it "should have stats" do
-    @commit.stats.files.should include(["PURE_TODO", 32, 0, 32])
+    expect(commit.stats.files).to include(["PURE_TODO", 32, 0, 32])
   end
 
   it "should return a single Gollum::Git::Tree object for Commit#tree" do
-    @commit.tree.should be_a Gollum::Git::Tree
+    expect(commit.tree).to be_a Gollum::Git::Tree
   end
-  
+
 end

--- a/spec/gollum_git_git_spec.rb
+++ b/spec/gollum_git_git_spec.rb
@@ -1,53 +1,53 @@
 require 'spec_helper'
 
 describe Gollum::Git::Git do
-  before(:each) do
-    @repo = Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true)
-    @git = @repo.git
-  end
+
+  let(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true) }
+
+  subject(:git) { repo.git }
 
   it "should have an exist? method" do
-    @git.should respond_to(:exist?)
+    expect(git).to respond_to(:exist?)
   end
 
   it "should have a push method" do
-    (2..3).each{|i| @git.should respond_to(:push).with(i).arguments}
+    (2..3).each{|i| expect(git).to respond_to(:push).with(i).arguments}
   end
 
   it "should have a pull method" do
-    (2..3).each{|i| @git.should respond_to(:pull).with(i).arguments}
+    (2..3).each{|i| expect(git).to respond_to(:pull).with(i).arguments}
   end
   
   it "should have a grep method" do
-    @git.should respond_to(:grep).with(2).arguments
+    expect(git).to respond_to(:grep).with(2).arguments
   end
 
   it "should have an rm method" do
-    @git.should respond_to(:rm)
+    expect(git).to respond_to(:rm)
   end
 
   context "Gollum specific methods" do
     it "should have a versions_for_path method" do
-        @git.should respond_to(:versions_for_path).with(3).arguments
+        expect(git).to respond_to(:versions_for_path).with(3).arguments
     end
   end
 
   context "porcelain API" do
 
     it "should have the ls_files method" do
-      @git.should respond_to(:ls_files).with(2).arguments
+      expect(git).to respond_to(:ls_files).with(2).arguments
     end
-  
+
     it "should have a checkout method" do
-      @git.should respond_to(:checkout).with(3).arguments
+      expect(git).to respond_to(:checkout).with(3).arguments
     end
-  
+
     it "should have an apply_path method" do
-      (1..2).each{|i| @git.should respond_to(:apply_patch).with(i).arguments}
+      (1..2).each{|i| expect(git).to respond_to(:apply_patch).with(i).arguments}
     end
-  
+
     it "should have a cat_file method" do
-      @git.should respond_to(:cat_file).with(2).arguments
+      expect(git).to respond_to(:cat_file).with(2).arguments
     end
 
   end

--- a/spec/gollum_git_index_spec.rb
+++ b/spec/gollum_git_index_spec.rb
@@ -1,35 +1,35 @@
 require 'spec_helper'
 
 describe Gollum::Git::Index do
-  before(:each) do
-    @repo = Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true)
-    @index = @repo.index
-  end
+
+  let(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true) }
+
+  subject(:index) { repo.index }
 
   it "should respond to add, delete and commit" do
-    @index.should respond_to(:add).with(2).arguments
-    @index.should respond_to(:delete).with(1).argument
-    @index.should respond_to(:commit).with(1).argument
-    @index.should respond_to(:commit).with(5).arguments
+    expect(index).to respond_to(:add).with(2).arguments
+    expect(index).to respond_to(:delete).with(1).argument
+    expect(index).to respond_to(:commit).with(1).argument
+    expect(index).to respond_to(:commit).with(5).arguments
   end
 
   it "should return a hashmap for Index#tree" do
-    @index.tree.should be_a Hash
+    expect(index.tree).to be_a Hash
   end
 
   it "should have a read_tree method" do
-    @index.should respond_to(:read_tree).with(1).argument
+    expect(index).to respond_to(:read_tree).with(1).argument
   end
 
   it "should load the current tree with Index#read_tree" do
-    @index.current_tree.should be_nil 
-    @index.read_tree(@repo.head.commit.id)
-    @index.current_tree.should_not be_nil
+    expect(index.current_tree).to be_nil
+    index.read_tree(repo.head.commit.id)
+    expect(index.current_tree).to_not be_nil
   end
 
   it "should return a Gollum::Git::Tree for Index#current_tree" do
-    @index.read_tree(@repo.head.commit.id)
-    @index.current_tree.should be_a Gollum::Git::Tree
+    index.read_tree(repo.head.commit.id)
+    expect(index.current_tree).to be_a Gollum::Git::Tree
   end
 
 end

--- a/spec/gollum_git_ref_spec.rb
+++ b/spec/gollum_git_ref_spec.rb
@@ -1,16 +1,17 @@
 require 'spec_helper'
 
 describe Gollum::Git::Ref do
-  before(:each) do
-    @repo = Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true)
-    @ref = @repo.head
-  end
+
+  let(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true) }
+
+  subject(:ref) { repo.head }
 
   it "should have a name method" do
-    @ref.should respond_to(:name)
+    expect(ref).to respond_to(:name)
   end
 
   it "should return a Gollum::Git::Commit for Ref#commit" do
-    @ref.commit.should be_a Gollum::Git::Commit
+    expect(ref.commit).to be_a Gollum::Git::Commit
   end
+
 end

--- a/spec/gollum_git_repo_modification_spec.rb
+++ b/spec/gollum_git_repo_modification_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'rspec/expectations'
+require 'tmpdir'
 
 RSpec::Matchers.define :a_blob_named do |expected|
   match do |actual|
@@ -9,13 +10,27 @@ end
 
 describe Gollum::Git::Repo do
 
+  def testrepo
+    tmp = Dir.mktmpdir
+    FileUtils.cp_r(File.join(fixture('dot_bare_git'), '.'), tmp)
+    tmp
+  end
+
+  before(:all) do
+    @tmp = testrepo
+  end
+
+  after(:all) do
+    FileUtils.remove_entry(@tmp)
+  end
+
   after(:each) do
     if parent_commit != repo.head.commit
       repo.update_ref(repo.head.name, parent_commit.id)
     end
   end
 
-  let(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true) }
+  let(:repo) { Gollum::Git::Repo.new(@tmp, :is_bare => true) }
 
   let(:index) do
     repo.index.read_tree(repo.head.commit.tree.id)

--- a/spec/gollum_git_repo_modification_spec.rb
+++ b/spec/gollum_git_repo_modification_spec.rb
@@ -8,6 +8,7 @@ RSpec::Matchers.define :a_blob_named do |expected|
 end
 
 describe Gollum::Git::Repo do
+
   after(:each) do
     if parent_commit != repo.head.commit
       repo.update_ref(repo.head.name, parent_commit.id)
@@ -32,7 +33,9 @@ describe Gollum::Git::Repo do
   end
 
   describe "#head#commit" do
+
     context "after committing" do
+
       before(:each) do
         index.add('Add.txt', 'Some data')
         commit_index
@@ -41,17 +44,17 @@ describe Gollum::Git::Repo do
       subject(:commit) { repo.head.commit }
 
       it "has the expected message" do
-        commit.message.should == message
+        expect(commit.message).to eq message
       end
 
       it "has the expected author" do
-        commit.author.name.should == actor.name
-        commit.author.email.should == actor.email
+        expect(commit.author.name).to eq actor.name
+        expect(commit.author.email).to eq actor.email
       end
 
       it "has a recent authored_date" do
-        commit.authored_date.should be < Time.now
-        commit.authored_date.should be > Time.now - 1
+        expect(commit.authored_date).to be < Time.now
+        expect(commit.authored_date).to be > Time.now - 1
       end
 
       it "has the expected id" do
@@ -69,26 +72,32 @@ describe Gollum::Git::Repo do
           "commit #{expected_content.bytesize}\0#{expected_content}"
         expected_sha = Digest::SHA1.hexdigest(expected_commit)
 
-        commit.id.should == expected_sha
+        expect(commit.id).to eq expected_sha
       end
+
     end
+
   end
 
   describe "#head#commit#tree" do
+
     subject(:tree) { repo.head.commit.tree }
 
     context "initially" do
       it "does not have a blob named 'Add.txt'" do
-        tree.blobs.should_not include( a_blob_named('Add.txt') )
+        expect(tree.blobs).to_not include( a_blob_named('Add.txt') )
       end
 
       it "has a blob named 'History.txt'" do
-        tree.blobs.should include( a_blob_named('History.txt') )
+        expect(tree.blobs).to include( a_blob_named('History.txt') )
       end
+
     end
 
     context "after adding a new file" do
+
       let(:filename) { 'Add.txt' }
+
       let(:data) { 'Some data' }
 
       before(:each) do
@@ -97,17 +106,20 @@ describe Gollum::Git::Repo do
       end
 
       it "has a blob with the name of the added file" do
-        tree.blobs.should include( a_blob_named(filename) )
+        expect(tree.blobs).to include( a_blob_named(filename) )
       end
 
       it "has a blob of that name with the expected data" do
         blob = tree.blobs.select { |blob| blob.name == filename }.first
-        blob.data.should == data
+        expect(blob.data).to eq data
       end
+
     end
 
     context "after modifying file 'History.txt'" do
+
       let(:filename) { 'History.txt' }
+
       let(:data) { 'Some data' }
 
       before(:each) do
@@ -116,16 +128,17 @@ describe Gollum::Git::Repo do
       end
 
       it "has a blob named with the name of the modified file" do
-        tree.blobs.should include( a_blob_named(filename) )
+        expect(tree.blobs).to include( a_blob_named(filename) )
       end
 
       it "has a blob of that name with the expected data" do
         blob = tree.blobs.select { |blob| blob.name == filename }.first
-        blob.data.should == data
+        expect(blob.data).to eq data
       end
     end
 
     context "after deleting a file", :skip => true do
+
       let(:filename) { 'History.txt' }
 
       before(:each) do
@@ -134,8 +147,9 @@ describe Gollum::Git::Repo do
       end
 
       it "does not have a blob with that name anymore" do
-        tree.blobs.should_not include( a_blob_named(filename) )
+        expect(tree.blobs).to_not include( a_blob_named(filename) )
       end
+
     end
 
   end

--- a/spec/gollum_git_repo_modification_spec.rb
+++ b/spec/gollum_git_repo_modification_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper'
+require 'rspec/expectations'
+
+RSpec::Matchers.define :a_blob_named do |expected|
+  match do |actual|
+    actual.is_a?(Gollum::Git::Blob) && actual.name == expected
+  end
+end
+
+describe Gollum::Git::Repo do
+  after(:each) do
+    if parent_commit != repo.head.commit
+      repo.update_ref(repo.head.name, parent_commit.id)
+    end
+  end
+
+  let(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true) }
+
+  let(:index) do
+    repo.index.read_tree(repo.head.commit.tree.id)
+    repo.index
+  end
+
+  let(:actor) { Gollum::Git::Actor.new("Tom Werner", "tom@example.com") }
+
+  let(:message) { 'Test commit' }
+
+  let(:parent_commit) { repo.head.commit }
+
+  def commit_index
+    index.commit(message, [parent_commit], actor, nil, repo.head.name)
+  end
+
+  describe "#head#commit" do
+    context "after committing" do
+      before(:each) do
+        index.add('Add.txt', 'Some data')
+        commit_index
+      end
+
+      subject(:commit) { repo.head.commit }
+
+      it "has the expected message" do
+        commit.message.should == message
+      end
+
+      it "has the expected author" do
+        commit.author.name.should == actor.name
+        commit.author.email.should == actor.email
+      end
+
+      it "has a recent authored_date" do
+        commit.authored_date.should be < Time.now
+        commit.authored_date.should be > Time.now - 1
+      end
+
+      it "has the expected id" do
+        # That also checks parent, committer and committed_date
+        # A change in any of these will cause an id mismatch
+        date = commit.authored_date
+        expected_content =
+          "tree #{commit.tree.id}\n" +
+          "parent #{parent_commit.id}\n" +
+          "author #{actor.output(date)}\n" +
+          "committer #{actor.output(date)}\n" +
+          "\n" +
+          "#{message}"
+        expected_commit =
+          "commit #{expected_content.bytesize}\0#{expected_content}"
+        expected_sha = Digest::SHA1.hexdigest(expected_commit)
+
+        commit.id.should == expected_sha
+      end
+    end
+  end
+
+  describe "#head#commit#tree" do
+    subject(:tree) { repo.head.commit.tree }
+
+    context "initially" do
+      it "does not have a blob named 'Add.txt'" do
+        tree.blobs.should_not include( a_blob_named('Add.txt') )
+      end
+
+      it "has a blob named 'History.txt'" do
+        tree.blobs.should include( a_blob_named('History.txt') )
+      end
+    end
+
+    context "after adding a new file" do
+      let(:filename) { 'Add.txt' }
+      let(:data) { 'Some data' }
+
+      before(:each) do
+        index.add(filename, data)
+        commit_index
+      end
+
+      it "has a blob with the name of the added file" do
+        tree.blobs.should include( a_blob_named(filename) )
+      end
+
+      it "has a blob of that name with the expected data" do
+        blob = tree.blobs.select { |blob| blob.name == filename }.first
+        blob.data.should == data
+      end
+    end
+
+    context "after modifying file 'History.txt'" do
+      let(:filename) { 'History.txt' }
+      let(:data) { 'Some data' }
+
+      before(:each) do
+        index.add(filename, data)
+        commit_index
+      end
+
+      it "has a blob named with the name of the modified file" do
+        tree.blobs.should include( a_blob_named(filename) )
+      end
+
+      it "has a blob of that name with the expected data" do
+        blob = tree.blobs.select { |blob| blob.name == filename }.first
+        blob.data.should == data
+      end
+    end
+
+    context "after deleting a file", :skip => true do
+      let(:filename) { 'History.txt' }
+
+      before(:each) do
+        index.delete(filename)
+        commit_index
+      end
+
+      it "does not have a blob with that name anymore" do
+        tree.blobs.should_not include( a_blob_named(filename) )
+      end
+    end
+
+  end
+
+end

--- a/spec/gollum_git_repo_modification_spec.rb
+++ b/spec/gollum_git_repo_modification_spec.rb
@@ -8,13 +8,13 @@ RSpec::Matchers.define :a_blob_named do |expected|
   end
 end
 
-describe Gollum::Git::Repo do
+def testrepo
+  tmp = Dir.mktmpdir
+  FileUtils.cp_r(File.join(fixture('dot_bare_git'), '.'), tmp)
+  tmp
+end
 
-  def testrepo
-    tmp = Dir.mktmpdir
-    FileUtils.cp_r(File.join(fixture('dot_bare_git'), '.'), tmp)
-    tmp
-  end
+describe Gollum::Git::Repo do
 
   before(:all) do
     @tmp = testrepo

--- a/spec/gollum_git_repo_spec.rb
+++ b/spec/gollum_git_repo_spec.rb
@@ -2,38 +2,36 @@ require 'spec_helper'
 
 describe Gollum::Git::Repo do
 
-  before(:each) do
-    @repo = Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true)
-  end
-  
+  subject(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true) }
+
   it "should have a Gollum::Git::Repo::init_bare method" do
-    Gollum::Git::Repo.should respond_to(:init_bare)
+    expect(Gollum::Git::Repo).to respond_to(:init_bare)
   end
   
   it "should have a path method" do
-    @repo.should respond_to(:path)
+    expect(repo).to respond_to(:path)
   end
 
   it "should return a Gollum::Git::Git object for Repo#git" do
-    @repo.git.should be_a Gollum::Git::Git
+    expect(repo.git).to be_a Gollum::Git::Git
   end
 
   it "should return an array of Gollum::Git::Commit objects for Repo#commits" do
-    @repo.commits.should be_a Array
-    @repo.commits.each{|commit| commit.should be_a Gollum::Git::Commit}
+    expect(repo.commits).to be_a Array
+    repo.commits.each{|commit| expect(commit).to be_a Gollum::Git::Commit}
   end
 
   it "should return a Gollum::Git::Ref object for Repo#head" do
-    @repo.head.should be_a Gollum::Git::Ref
+    expect(repo.head).to be_a Gollum::Git::Ref
   end
 
   it "should log returning an array of Gollum::Git::Commit" do
-    @repo.should respond_to(:log).with(3).arguments
-    @repo.log.first.should be_a Gollum::Git::Commit
+    expect(repo).to respond_to(:log).with(3).arguments
+    expect(repo.log.first).to be_a Gollum::Git::Commit
   end
 
   it "should have a diff method" do
-    (2..3).each{|i| @repo.should respond_to(:diff).with(i).arguments}
+    (2..3).each{|i| expect(repo).to respond_to(:diff).with(i).arguments}
   end
 
 end

--- a/spec/gollum_git_tree_spec.rb
+++ b/spec/gollum_git_tree_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe Gollum::Git::Tree do
-  before(:each) do
-    @repo = Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true)
-    @repo.index.read_tree(@repo.head.commit.tree.id)
-    @tree = @repo.index.current_tree
-  end
+
+  let(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), :is_bare => true) }
+
+  subject(:tree) { repo.head.commit.tree }
 
   it "should return an array of Gollum::Git::Blob objects for Tree#blobs" do
-    @tree.blobs.should be_a Array
-    @tree.blobs.each{|blob| blob.should be_a Gollum::Git::Blob}
+    expect(tree.blobs).to be_a Array
+    tree.blobs.each{|blob| expect(blob).to be_a Gollum::Git::Blob}
   end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,9 @@
 def fixture(name)
   File.join(File.dirname(__FILE__), 'fixtures', name)
 end
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
This spec file has a few tests for checking that an adapter modifies a
repository as Grit would, when using the form of the `Index#commit` call
used by `Gollum::Committer`.

In particular, one of the specs surfaces gollum/rugged_adapter#11
(where the name of the committer was not the same as the author's).

PR note: Please do not hesitate to modify, pull apart and rewrite the spec file that I added. (I have also checked that the specs run on the Grit, Rugged and RJGit adapters - with the exception of gollum/rugged_adapter#11, all the specs pass.