### PR TITLE
Fix a test for root_commit.parent

### DIFF
--- a/spec/gollum_git_commit_spec.rb
+++ b/spec/gollum_git_commit_spec.rb
@@ -41,6 +41,6 @@ describe Gollum::Git::Commit do
 
   it "returns a Gollum::Git::Commit object or nil for parent" do
     expect(commit.parent).to be_a Gollum::Git::Commit
-    expect(repo.commits.first.parent).to eq nil
+    expect(repo.commits.last.parent).to eq nil
   end
 end

--- a/spec/gollum_git_commit_spec.rb
+++ b/spec/gollum_git_commit_spec.rb
@@ -40,6 +40,7 @@ describe Gollum::Git::Commit do
   end
 
   it "returns a Gollum::Git::Commit object or nil for parent" do
+    expect(repo.commits.size).to be < 10 # to ensure commits.last is the root
     expect(commit.parent).to be_a Gollum::Git::Commit
     expect(repo.commits.last.parent).to eq nil
   end


### PR DESCRIPTION
The previous PR #11 had a bug: `commits.first` is the latest commit.

But `commits.last` is, however, not always the root commit because it passes `max_count = 10` to `git.log` by default.