### PR TITLE
Add specs related to new branch discover logic

### DIFF
--- a/spec/gollum_git_repo_spec.rb
+++ b/spec/gollum_git_repo_spec.rb
@@ -46,4 +46,11 @@ describe Gollum::Git::Repo do
     patch = repo.diff(repo.commits[0].id, repo.commits[1].id)
     expect(patch.encoding.to_s).to eq 'UTF-8'
   end
+
+  it "finds a branch from a list of branch names" do
+    expect(repo).to respond_to(:find_branch).with(1).arguments
+    expect(repo.find_branch(['master'])).to eq 'master'
+    expect(repo.find_branch(['testing', 'master'])).to eq 'testing'
+    expect(repo.find_branch(['foo'])).to be_nil
+  end
 end

--- a/spec/gollum_git_spec.rb
+++ b/spec/gollum_git_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Gollum::Git do
+    it "returns the global default branch" do
+        expect(Gollum::Git).to respond_to(:global_default_branch).with(0).arguments
+        expect(Gollum::Git.global_default_branch).to eq `git config --global init.defaultBranch`.chomp
+    end
+end


### PR DESCRIPTION
This works towards a solution to https://github.com/gollum/gollum/issues/1813 by demanding the adapters have methods for discovering branches on a repo, and for discovering the global default branch.