### PR TITLE
Add spec for Tree#find_blob and expect mode to work

### DIFF
--- a/spec/gollum_git_tree_spec.rb
+++ b/spec/gollum_git_tree_spec.rb
@@ -9,7 +9,7 @@ describe Gollum::Git::Tree do
   it "finds a blob by name" do
     result = tree.find_blob('Döner.md')
     expect(result).to be_a Gollum::Git::Blob
-    expect(result.mode).to eq '100644'
+    expect(result.mode).to eq 0100644
     result = tree.find_blob('Noexist.foo')
     expect(result).to be_nil
   end
@@ -18,7 +18,7 @@ describe Gollum::Git::Tree do
     expect(tree.blobs).to be_a Array
     tree.blobs.each do |blob|
       expect(blob).to be_a Gollum::Git::Blob
-      expect(blob.mode).to eq '100644'
+      expect(blob.mode).to eq 0100644
     end
   end
 

--- a/spec/gollum_git_tree_spec.rb
+++ b/spec/gollum_git_tree_spec.rb
@@ -6,9 +6,20 @@ describe Gollum::Git::Tree do
 
   subject(:tree) { repo.head.commit.tree }
 
+  it "finds a blob by name" do
+    result = tree.find_blob('Döner.md')
+    expect(result).to be_a Gollum::Git::Blob
+    expect(result.mode).to eq '100644'
+    result = tree.find_blob('Noexist.foo')
+    expect(result).to be_nil
+  end
+
   it "returns an array of Gollum::Git::Blob objects for Tree#blobs" do
     expect(tree.blobs).to be_a Array
-    tree.blobs.each{|blob| expect(blob).to be_a Gollum::Git::Blob}
+    tree.blobs.each do |blob|
+      expect(blob).to be_a Gollum::Git::Blob
+      expect(blob.mode).to eq '100644'
+    end
   end
 
 end


### PR DESCRIPTION
Proposed changes to the spec to account for some features we want in https://github.com/gollum/gollum-lib/pull/437:

* Previously, the mode for each of the Blobs in the result of `Tree#blobs`  was not being set. This means that symlinks aren't adequately detected.
* Add a method `Tree#find_blob` that searches a single blob by name, instead of looping over all blobs in a tree.