### PR TITLE
Specs for Index#workdir_path_modified?

### DIFF
--- a/spec/gollum_git_index_spec.rb
+++ b/spec/gollum_git_index_spec.rb
@@ -2,9 +2,11 @@ require 'spec_helper'
 
 describe Gollum::Git::Index do
 
-  let(:repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), is_bare: true) }
+  let(:bare_repo) { Gollum::Git::Repo.new(fixture('dot_bare_git'), is_bare: true) }
+  subject(:index) { bare_repo.index }
 
-  subject(:index) { repo.index }
+  let(:repo) { Gollum::Git::Repo.new(cloned_testpath(fixture('dot_bare_git')), is_bare: false) }
+  subject(:index_with_worktree) { repo.index }
 
   it "responds to add, delete and commit" do
     expect(index).to respond_to(:add).with(2).arguments
@@ -23,13 +25,32 @@ describe Gollum::Git::Index do
 
   it "loads the current tree with Index#read_tree" do
     expect(index.current_tree).to be_nil
-    index.read_tree(repo.head.commit.id)
+    index.read_tree(bare_repo.head.commit.id)
     expect(index.current_tree).to_not be_nil
   end
 
   it "returns a Gollum::Git::Tree for Index#current_tree" do
-    index.read_tree(repo.head.commit.id)
+    index.read_tree(bare_repo.head.commit.id)
     expect(index.current_tree).to be_a Gollum::Git::Tree
+  end
+
+  it "determines whether a path in the workdir has new content for a non-bare repo" do
+    path = 'History.txt'
+    expect(index_with_worktree.workdir_path_modified?(path)).to be false
+
+    filepath = File.join(repo.path, '../', path)
+    f = File.open(filepath, 'w')
+    f.puts "Workdir no longer clean"
+    f.close
+    
+    expect(index_with_worktree.workdir_path_modified?('History.txt')).to be true
+
+    File.delete(filepath)
+    expect(index_with_worktree.workdir_path_modified?('History.txt')).to be false
+  end
+
+  it "returns false for #workdir_path_modified? if repo is bare" do
+    expect(index.workdir_path_modified?('History.txt')).to be false
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,14 @@ def fixture(name)
   File.join(File.dirname(__FILE__), 'fixtures', name)
 end
 
+def cloned_testpath(path, bare = false)
+  tmpdir = Dir.mktmpdir(self.class.name)
+  bare   = bare ? "--bare" : ""
+  redirect = Gem.win_platform? ? '' : '2>/dev/null'
+  %x{git clone #{bare} '#{path}' #{tmpdir} #{redirect}}
+  tmpdir
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
`Index#workdir_path_modified?` should determine whether a path in the working directory has been modified compared to the index: i.e., whether it is new, or has new content. The purpose of this method is to determine whether it is safe to overwrite a path with information from the index. Hence, when path does not exist in the workdir (in rugged, this is signified by `:worktree_deleted`), this method should return `false`.